### PR TITLE
Blockstack server-side validation

### DIFF
--- a/backend/boltathon/util/blockstack.py
+++ b/backend/boltathon/util/blockstack.py
@@ -1,0 +1,27 @@
+import requests
+from jose import jwt
+from flask import current_app
+from boltathon.util.errors import RequestError
+
+# Given a Blockstack private key, validate that it was signed by the same
+# key as owns a username
+def validate_blockstack_auth(id, username, token):
+    try:
+        # Match up data with arguments
+        token = jwt.decode(token, [], options={ 'verify_signature': False })
+        if username != token.get('username'):
+            return False
+        if id not in token.get('profile_url'):
+            return False
+
+        # Match up data with Blockstack's atlas node
+        res = requests.get(f'https://core.blockstack.org/v1/names/{username}')
+        res = res.json()
+        if res.get('address') != id:
+            return False
+
+        return True
+    except Exception as e:
+        print(e)
+        current_app.logger.error(f'Could not lookup username {username} from blockstack.org: {e}')
+        raise RequestError(code=500, message='Failed to lookup Blockstack identity')

--- a/backend/boltathon/views/api.py
+++ b/backend/boltathon/views/api.py
@@ -8,6 +8,7 @@ from boltathon.util.auth import requires_auth
 from boltathon.util.node import get_pubkey_from_credentials, make_invoice, lookup_invoice
 from boltathon.util.errors import RequestError
 from boltathon.util.mail import send_email_once
+from boltathon.util.blockstack import validate_blockstack_auth
 from boltathon.models.user import User, self_user_schema, public_user_schema, public_users_schema
 from boltathon.models.connection import Connection, public_connections_schema
 from boltathon.models.tip import Tip, tip_schema, tips_schema
@@ -164,10 +165,14 @@ def get_tip(tip_id):
 @use_args({
   'id': fields.Str(required=True),
   'username': fields.Str(required=True),
+  'token': fields.Str(required=True),
 })
 def blockstack_auth(args):
-  # TODO: Server-side verification
-   # Find or create a new user and add the connection
+  # Assert that they generated a valid token
+  if not validate_blockstack_auth(args.get('id'), args.get('username'), args.get('token')):
+    raise RequestError(code=400, message='Invalid Blockstack token provided')
+
+  # Find or create a new user and add the connection
   user = Connection.get_user_by_connection(
       site='blockstack',
       site_id=args.get('id'),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,6 @@ bitstring==3.1.5
 webargs==5.2.0
 flask-cors==3.0.7
 sendgrid==6.0.4
+
+# JWT package that supports ES256K for blockstack
+git+git://github.com/pohutukawa/python-jose@28cd302d#egg=python-jose

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -93,6 +93,7 @@ class API {
     return this.request<SelfUser>('POST', '/auth/blockstack', {
       id: data.identityAddress,
       username: data.username,
+      token: data.authResponseToken,
     });
   }
 

--- a/frontend/src/pages/BlockstackAuth.tsx
+++ b/frontend/src/pages/BlockstackAuth.tsx
@@ -1,20 +1,39 @@
 import React from 'react';
-import { Loader } from 'semantic-ui-react';
+import { Loader, Message } from 'semantic-ui-react';
 import { withRouter, RouteComponentProps } from 'react-router';
 import * as blockstack from 'blockstack.js';
 import { UserData } from 'blockstack.js/lib/auth/authApp';
-import api, { User } from '../api';
+import api from '../api';
 
-class BlockstackAuth extends React.Component<RouteComponentProps> {
+interface State {
+  error: string | null;
+}
+
+class BlockstackAuth extends React.Component<RouteComponentProps, State> {
+  state: State = {
+    error: null,
+  };
+
   componentDidMount() {
     if (blockstack.isUserSignedIn()) {
       this.auth(blockstack.loadUserData());
     } else if (blockstack.isSignInPending()) {
-      blockstack.handlePendingSignIn().then(this.auth)
+      blockstack.handlePendingSignIn().then(this.auth);
     }
   }
 
   render() {
+    const { error } = this.state;
+
+    if (error) {
+      return (
+        <Message negative>
+          <Message.Header>Failed to authenticate with Blockstack</Message.Header>
+          <Message.Content>{error}</Message.Content>
+        </Message>
+      );
+    }
+
     return <Loader size="huge" active>Connecting to Blockstack...</Loader>;
   }
 
@@ -23,7 +42,7 @@ class BlockstackAuth extends React.Component<RouteComponentProps> {
     api.blockstackAuth(data).then(res => {
       history.replace('/user/me');
     }).catch(err => {
-      alert(err.message);
+      this.setState({ error: err.message });
     });
   };
 };


### PR DESCRIPTION
Closes #10.

### What This Does

Actually validates the information the user sends us about their Blockstack account by decoding their auth token, and looking up the data on Blockstack's Atlas node. This is still somewhat trusted since we're using their node, but I think the risks are _pretty low_ on this one.

In order to decode a ES256K json web token, I had to use the version of the package that's [currently in a pull request](https://github.com/mpdavis/python-jose/pull/113). Once that's merged and updated, we can use a pypi version.

### Steps to Test

Auth with blockstack and confirm it works! Hard to test the negative use case (Someone spoofing a login) without editing the code, but you can give that a shot too.