### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+frontend/yarn.lock linguist-generated=true
+frontend/src/style/semantic-ui-theme.css linguist-vendored=true


### PR DESCRIPTION
This is a silly little PR, it just marks `yarn.lock` and `semantic-ui-theme.css` as generated and vendor'd files respectively so that TipHub doesn't look like a "CSS" project!