### PR TITLE
Move invoice checks to a background thread

### DIFF
--- a/backend/boltathon/util/node.py
+++ b/backend/boltathon/util/node.py
@@ -1,13 +1,33 @@
-from boltathon.util.lnaddr import lndecode
-from boltathon.util.errors import RequestError
 import rpc_pb2 as ln
 import rpc_pb2_grpc as lnrpc
 import grpc
+from time import time
 from base64 import b64decode
+from boltathon.extensions import db
+from boltathon.util.lnaddr import lndecode
+from boltathon.util.errors import RequestError
+
+EXPIRY_SECONDS = 300
 
 def make_invoice(node_url: str, macaroon: str, cert: str):
   stub = get_stub(node_url, macaroon, cert)
-  return stub.AddInvoice(ln.Invoice(), timeout=10)
+  return stub.AddInvoice(ln.Invoice(expiry=EXPIRY_SECONDS), timeout=10)
+
+def watch_and_update_tip_invoice(app, tip, invoice):
+  expiration = time() + EXPIRY_SECONDS
+  stub = get_stub(tip.recipient.node_url, tip.recipient.macaroon, tip.recipient.cert)
+  request = ln.InvoiceSubscription(add_index=invoice.add_index)
+  for inv in stub.SubscribeInvoices(request):
+    # If the invoice we're watching has expired anyway, break out
+    if time() > expiration:
+      break
+
+    # If it's our invoice that's been paid, mark it as such and break out
+    if inv.r_hash.hex() == invoice.r_hash.hex() and hasattr(inv, 'amt_paid_sat') and inv.amt_paid_sat:
+      with app.app_context():
+        tip.confirm(inv.amt_paid_sat)
+        db.session.commit()
+      break
 
 def get_pubkey_from_credentials(node_url: str, macaroon: str, cert: str):
   try:


### PR DESCRIPTION
Closes #14.

### What This Does

Moves invoice payment checking to a background thread so that if you tip and leave the page, it's still counted. Also reduces the amount we pound the receiver's node for invoice updates.

### Steps to Test

1. Make a new tip, complete it with the page open, confirm you get an on-page confirmation & email.
2. Make a new tip, complete it _after closing the page, confirm you get a confirmation email.